### PR TITLE
feat: add server provisioning automation

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -e
+
+# Server provisioning - Linux only
+if [[ "$(uname)" != "Linux" ]]; then
+    echo "❌ This script is for Linux servers only"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_DIR="$SCRIPT_DIR/server"
+
+source "$SERVER_DIR/packages.sh"
+source "$SERVER_DIR/tools.sh"
+source "$SERVER_DIR/infra/firewall.sh"
+source "$SERVER_DIR/infra/dns.sh"
+
+usage() {
+    echo "Usage: ./server.sh <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  bootstrap              Full setup: packages + tools"
+    echo "  packages               Install system packages (mosh, caddy, docker)"
+    echo "  tools                  Install CLI tools (hcloud, flarectl)"
+    echo "  caddy add <domain> <port>  Add site to Caddy"
+    echo "  firewall setup         Create firewall with default rules"
+    echo "  firewall status        Show current rules"
+    echo "  firewall open <port> <protocol>  Add rule"
+    echo "  dns list <zone>        List DNS records"
+    echo "  dns add <zone> <name> <ip>  Add A record"
+    echo "  dns delete <zone> <record-id>  Remove record"
+}
+
+cmd_bootstrap() {
+    echo "🚀 Server bootstrap starting..."
+    cmd_packages
+    cmd_tools
+    echo ""
+    echo "✅ Server bootstrap complete"
+    echo "📋 Manual steps:"
+    echo "   👉 Add tokens to ~/.secrets:"
+    echo "      export HCLOUD_TOKEN='xxx'"
+    echo "      export CF_API_TOKEN='xxx'"
+    echo "   👉 Run: source ~/.zshrc"
+}
+
+cmd_packages() {
+    install_mosh
+    install_caddy
+    install_docker
+    install_go
+}
+
+cmd_tools() {
+    install_hcloud
+    install_flarectl
+}
+
+cmd_caddy() {
+    local subcmd="$1"
+    shift || true
+
+    case "$subcmd" in
+        add)
+            local domain="$1"
+            local port="$2"
+            if [[ -z "$domain" || -z "$port" ]]; then
+                echo "Usage: ./server.sh caddy add <domain> <port>"
+                exit 1
+            fi
+            caddy_add_site "$domain" "$port"
+            ;;
+        *)
+            echo "Usage: ./server.sh caddy add <domain> <port>"
+            exit 1
+            ;;
+    esac
+}
+
+cmd_firewall() {
+    local subcmd="$1"
+    shift || true
+
+    case "$subcmd" in
+        setup)
+            firewall_setup
+            ;;
+        status)
+            firewall_status
+            ;;
+        open)
+            local port="$1"
+            local protocol="${2:-tcp}"
+            if [[ -z "$port" ]]; then
+                echo "Usage: ./server.sh firewall open <port> [protocol]"
+                exit 1
+            fi
+            firewall_open "$port" "$protocol"
+            ;;
+        *)
+            echo "Usage: ./server.sh firewall <setup|status|open>"
+            exit 1
+            ;;
+    esac
+}
+
+cmd_dns() {
+    local subcmd="$1"
+    shift || true
+
+    case "$subcmd" in
+        list)
+            local zone="$1"
+            if [[ -z "$zone" ]]; then
+                echo "Usage: ./server.sh dns list <zone>"
+                exit 1
+            fi
+            dns_list "$zone"
+            ;;
+        add)
+            local zone="$1"
+            local name="$2"
+            local ip="$3"
+            if [[ -z "$zone" || -z "$name" || -z "$ip" ]]; then
+                echo "Usage: ./server.sh dns add <zone> <name> <ip>"
+                exit 1
+            fi
+            dns_add "$zone" "$name" "$ip"
+            ;;
+        delete)
+            local zone="$1"
+            local record_id="$2"
+            if [[ -z "$zone" || -z "$record_id" ]]; then
+                echo "Usage: ./server.sh dns delete <zone> <record-id>"
+                exit 1
+            fi
+            dns_delete "$zone" "$record_id"
+            ;;
+        *)
+            echo "Usage: ./server.sh dns <list|add|delete>"
+            exit 1
+            ;;
+    esac
+}
+
+# Main command routing
+case "${1:-}" in
+    bootstrap)
+        cmd_bootstrap
+        ;;
+    packages)
+        cmd_packages
+        ;;
+    tools)
+        cmd_tools
+        ;;
+    caddy)
+        shift
+        cmd_caddy "$@"
+        ;;
+    firewall)
+        shift
+        cmd_firewall "$@"
+        ;;
+    dns)
+        shift
+        cmd_dns "$@"
+        ;;
+    -h|--help|"")
+        usage
+        ;;
+    *)
+        echo "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+esac

--- a/server/caddy/Caddyfile
+++ b/server/caddy/Caddyfile
@@ -1,0 +1,7 @@
+# Global options
+{
+	email admin@example.com
+}
+
+# Import site-specific configurations
+import /etc/caddy/sites/*.caddy

--- a/server/docs/new-domain.md
+++ b/server/docs/new-domain.md
@@ -1,0 +1,78 @@
+# Adding a New Domain/Subdomain
+
+## 1. Add DNS Record
+
+```bash
+# Get server IP
+ip addr show eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1
+
+# Add A record
+./server.sh dns add example.com subdomain <ip>
+
+# Or for apex domain
+./server.sh dns add example.com @ <ip>
+```
+
+## 2. Create Caddy Site Config
+
+```bash
+# Add site configuration
+./server.sh caddy add subdomain.example.com 3000
+```
+
+This creates `/etc/caddy/sites/subdomain.example.com.caddy`:
+
+```
+subdomain.example.com {
+    reverse_proxy localhost:3000
+}
+```
+
+## 3. Reload Caddy
+
+```bash
+sudo systemctl reload caddy
+```
+
+## 4. Verify SSL
+
+```bash
+# Check Caddy logs for certificate provisioning
+sudo journalctl -u caddy -f
+
+# Test HTTPS
+curl -I https://subdomain.example.com
+```
+
+## Custom Configurations
+
+For more complex setups, edit the site file directly:
+
+```bash
+sudo vim /etc/caddy/sites/subdomain.example.com.caddy
+```
+
+Example with additional options:
+
+```
+subdomain.example.com {
+    reverse_proxy localhost:3000 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+    }
+
+    encode gzip
+
+    log {
+        output file /var/log/caddy/subdomain.example.com.log
+    }
+}
+```
+
+## Checklist
+
+- [ ] DNS record added
+- [ ] Caddy site config created
+- [ ] Caddy reloaded
+- [ ] SSL certificate provisioned
+- [ ] Site accessible via HTTPS

--- a/server/docs/new-server.md
+++ b/server/docs/new-server.md
@@ -1,0 +1,81 @@
+# New Server Setup
+
+## 1. Create Server (Manual)
+
+Create in Hetzner Cloud console:
+- Location: Choose based on latency needs
+- Image: Ubuntu 24.04
+- Type: CX22 or similar
+- SSH key: Add your key
+- Name: Something memorable
+
+## 2. Initial SSH
+
+```bash
+ssh root@<ip>
+```
+
+## 3. Clone Dotfiles
+
+```bash
+cd ~
+git clone https://github.com/yourusername/dotfiles.git
+cd dotfiles
+```
+
+## 4. Run Install Scripts
+
+```bash
+# Install user configs (zsh, tmux, nvim)
+./install.sh bootstrap
+./install.sh
+
+# Install server packages and tools
+./server.sh bootstrap
+```
+
+## 5. Configure Secrets
+
+Add to `~/.secrets`:
+
+```bash
+export HCLOUD_TOKEN='your-token-here'
+export CF_API_TOKEN='your-token-here'
+```
+
+Then reload:
+
+```bash
+source ~/.zshrc
+```
+
+## 6. Setup Firewall
+
+```bash
+./server.sh firewall setup
+
+# Apply to this server
+hcloud firewall apply-to-resource default --type server --server <server-name>
+```
+
+## 7. Verify Tools
+
+```bash
+hcloud server list
+flarectl zone list
+```
+
+## 8. Add First Site
+
+See [new-domain.md](new-domain.md) for adding domains.
+
+## Checklist
+
+- [ ] Server created in Hetzner
+- [ ] SSH access working
+- [ ] Dotfiles cloned
+- [ ] `./install.sh bootstrap && ./install.sh` completed
+- [ ] `./server.sh bootstrap` completed
+- [ ] Secrets configured in `~/.secrets`
+- [ ] Firewall created and applied
+- [ ] Tools verified working

--- a/server/infra/dns.sh
+++ b/server/infra/dns.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Cloudflare DNS wrapper using flarectl
+
+check_flarectl() {
+    if ! command -v flarectl &>/dev/null; then
+        echo "❌ flarectl not found. Run ./server.sh tools first"
+        exit 1
+    fi
+
+    if [[ -z "$CF_API_TOKEN" ]]; then
+        echo "❌ CF_API_TOKEN not set. Add to ~/.secrets"
+        exit 1
+    fi
+}
+
+dns_list() {
+    local zone="$1"
+
+    check_flarectl
+
+    echo "DNS records for $zone:"
+    flarectl dns list --zone "$zone"
+}
+
+dns_add() {
+    local zone="$1"
+    local name="$2"
+    local ip="$3"
+
+    check_flarectl
+
+    echo "Adding A record: $name.$zone -> $ip"
+
+    flarectl dns create \
+        --zone "$zone" \
+        --name "$name" \
+        --type A \
+        --content "$ip" \
+        --proxy=false
+
+    echo "✅ DNS record added"
+    echo "   👉 DNS propagation may take a few minutes"
+}
+
+dns_delete() {
+    local zone="$1"
+    local record_id="$2"
+
+    check_flarectl
+
+    echo "Deleting record $record_id from $zone..."
+
+    flarectl dns delete --zone "$zone" --id "$record_id"
+
+    echo "✅ DNS record deleted"
+}

--- a/server/infra/firewall.sh
+++ b/server/infra/firewall.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Hetzner Cloud firewall wrapper
+
+FIREWALL_NAME="default"
+
+check_hcloud() {
+    if ! command -v hcloud &>/dev/null; then
+        echo "❌ hcloud not found. Run ./server.sh tools first"
+        exit 1
+    fi
+
+    if [[ -z "$HCLOUD_TOKEN" ]]; then
+        echo "❌ HCLOUD_TOKEN not set. Add to ~/.secrets"
+        exit 1
+    fi
+}
+
+firewall_setup() {
+    check_hcloud
+
+    # Check if firewall exists
+    if hcloud firewall describe "$FIREWALL_NAME" &>/dev/null; then
+        echo "✓ Firewall '$FIREWALL_NAME' already exists"
+        firewall_status
+        return
+    fi
+
+    echo "Creating firewall '$FIREWALL_NAME'..."
+
+    hcloud firewall create --name "$FIREWALL_NAME"
+
+    # SSH
+    hcloud firewall add-rule "$FIREWALL_NAME" \
+        --direction in \
+        --protocol tcp \
+        --port 22 \
+        --source-ips 0.0.0.0/0 \
+        --source-ips ::/0 \
+        --description "SSH"
+
+    # HTTP
+    hcloud firewall add-rule "$FIREWALL_NAME" \
+        --direction in \
+        --protocol tcp \
+        --port 80 \
+        --source-ips 0.0.0.0/0 \
+        --source-ips ::/0 \
+        --description "HTTP"
+
+    # HTTPS
+    hcloud firewall add-rule "$FIREWALL_NAME" \
+        --direction in \
+        --protocol tcp \
+        --port 443 \
+        --source-ips 0.0.0.0/0 \
+        --source-ips ::/0 \
+        --description "HTTPS"
+
+    # Mosh (UDP 60000-61000)
+    hcloud firewall add-rule "$FIREWALL_NAME" \
+        --direction in \
+        --protocol udp \
+        --port 60000-61000 \
+        --source-ips 0.0.0.0/0 \
+        --source-ips ::/0 \
+        --description "Mosh"
+
+    echo "✅ Firewall created"
+    echo "📋 Manual steps:"
+    echo "   👉 Apply to server: hcloud firewall apply-to-resource $FIREWALL_NAME --type server --server <server-name>"
+}
+
+firewall_status() {
+    check_hcloud
+
+    echo "Firewall rules for '$FIREWALL_NAME':"
+    hcloud firewall describe "$FIREWALL_NAME" -o format='{{range .Rules}}{{.Direction}} {{.Protocol}} {{.Port}} {{.Description}}{{"\n"}}{{end}}'
+}
+
+firewall_open() {
+    local port="$1"
+    local protocol="${2:-tcp}"
+
+    check_hcloud
+
+    echo "Adding rule: $protocol/$port..."
+
+    hcloud firewall add-rule "$FIREWALL_NAME" \
+        --direction in \
+        --protocol "$protocol" \
+        --port "$port" \
+        --source-ips 0.0.0.0/0 \
+        --source-ips ::/0 \
+        --description "Custom $protocol/$port"
+
+    echo "✅ Rule added"
+}

--- a/server/packages.sh
+++ b/server/packages.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# System package installation
+
+install_mosh() {
+    if command -v mosh &>/dev/null; then
+        echo "✓ mosh already installed"
+        return
+    fi
+
+    echo "Installing mosh..."
+    sudo apt-get update
+    sudo apt-get install -y mosh
+    echo "✅ mosh installed"
+}
+
+install_caddy() {
+    if command -v caddy &>/dev/null; then
+        echo "✓ caddy already installed"
+        return
+    fi
+
+    echo "Installing caddy..."
+    sudo apt-get update
+    sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+    sudo apt-get update
+    sudo apt-get install -y caddy
+
+    # Setup sites directory
+    sudo mkdir -p /etc/caddy/sites
+
+    # Install base Caddyfile if not exists
+    if [[ ! -f /etc/caddy/Caddyfile.bak ]]; then
+        sudo cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.bak 2>/dev/null || true
+    fi
+    sudo cp "$SERVER_DIR/caddy/Caddyfile" /etc/caddy/Caddyfile
+
+    sudo systemctl enable caddy
+    sudo systemctl restart caddy
+    echo "✅ caddy installed"
+}
+
+install_docker() {
+    if command -v docker &>/dev/null; then
+        echo "✓ docker already installed"
+        return
+    fi
+
+    echo "Installing docker..."
+    sudo apt-get update
+    sudo apt-get install -y ca-certificates curl
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+      $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+    # Add current user to docker group
+    sudo usermod -aG docker "$USER"
+
+    echo "✅ docker installed"
+    echo "   👉 Log out and back in for docker group to take effect"
+}
+
+install_go() {
+    if command -v go &>/dev/null; then
+        echo "✓ go already installed"
+        return
+    fi
+
+    echo "Installing go..."
+    local GO_VERSION="1.23.4"
+    local GO_ARCH="amd64"
+
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+    rm /tmp/go.tar.gz
+
+    echo "✅ go installed"
+    echo "   👉 Ensure PATH includes /usr/local/go/bin and ~/go/bin"
+}
+
+caddy_add_site() {
+    local domain="$1"
+    local port="$2"
+    local site_file="/etc/caddy/sites/${domain}.caddy"
+
+    if [[ -f "$site_file" ]]; then
+        echo "Site config already exists: $site_file"
+        echo "Edit manually: sudo vim $site_file"
+        return 1
+    fi
+
+    echo "Creating Caddy site config for $domain -> localhost:$port"
+
+    sudo tee "$site_file" > /dev/null <<EOF
+$domain {
+    reverse_proxy localhost:$port
+}
+EOF
+
+    echo "✅ Site config created: $site_file"
+    echo "📋 Manual steps:"
+    echo "   👉 Reload Caddy: sudo systemctl reload caddy"
+}

--- a/server/tools.sh
+++ b/server/tools.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# CLI tools installation via go install
+
+GO_BIN="/usr/local/go/bin/go"
+
+install_hcloud() {
+    if command -v hcloud &>/dev/null; then
+        echo "✓ hcloud already installed"
+        return
+    fi
+
+    echo "Installing hcloud..."
+
+    if [[ ! -x "$GO_BIN" ]]; then
+        echo "❌ Go not found. Run ./server.sh packages first"
+        exit 1
+    fi
+
+    $GO_BIN install github.com/hetznercloud/cli/cmd/hcloud@latest
+
+    # Symlink to /usr/local/bin
+    sudo ln -sf "$HOME/go/bin/hcloud" /usr/local/bin/hcloud
+
+    echo "✅ hcloud installed"
+}
+
+install_flarectl() {
+    if command -v flarectl &>/dev/null; then
+        echo "✓ flarectl already installed"
+        return
+    fi
+
+    echo "Installing flarectl..."
+
+    if [[ ! -x "$GO_BIN" ]]; then
+        echo "❌ Go not found. Run ./server.sh packages first"
+        exit 1
+    fi
+
+    $GO_BIN install github.com/cloudflare/cloudflare-go/cmd/flarectl@latest
+
+    # Symlink to /usr/local/bin
+    sudo ln -sf "$HOME/go/bin/flarectl" /usr/local/bin/flarectl
+
+    echo "✅ flarectl installed"
+}


### PR DESCRIPTION
## Summary

- Add `server.sh` entry point for server provisioning (Linux only)
- Install system packages: mosh, caddy, docker, go
- Install CLI tools via go: hcloud (Hetzner), flarectl (Cloudflare)
- Wrapper scripts for firewall and DNS management
- Documentation for new server and domain setup

## Commands

```bash
./server.sh bootstrap              # Full setup
./server.sh packages               # System packages only
./server.sh tools                  # CLI tools only
./server.sh caddy add <domain> <port>
./server.sh firewall setup|status|open
./server.sh dns list|add|delete
```

## Test plan

- [x] `./server.sh --help` shows usage
- [x] `./server.sh packages` detects already installed
- [x] `./server.sh tools` detects already installed  
- [x] `./server.sh dns list 1707.network` works
- [ ] `./server.sh firewall status` works (needs HCLOUD_TOKEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)